### PR TITLE
[nana] fixed build for windows

### DIFF
--- a/ports/nana/config.cmake.in
+++ b/ports/nana/config.cmake.in
@@ -7,11 +7,14 @@ if(UNIX)
   find_library(FONTCONFIG_LIB NAMES fontconfig)
 endif()
 
-if(@NANA_ENABLE_PNG@)
+option(NANA_ENABLE_PNG "Enable PNG support" @NANA_ENABLE_PNG@)
+option(NANA_ENABLE_JPEG "Enable JPEG support" @NANA_ENABLE_JPEG@)
+
+if(NANA_ENABLE_PNG)
   find_package(PNG REQUIRED)
 endif()
 
-if(@NANA_ENABLE_JPEG@)
+if(NANA_ENABLE_JPEG)
   find_package(JPEG REQUIRED)
 endif()
 
@@ -21,6 +24,6 @@ if(UNIX)
   target_link_libraries(unofficial::nana::nana INTERFACE ${FONTCONFIG_LIB} ${X11_LIBRARIES} ${X11_Xft_LIB})
 endif()
 
-if(@NANA_ENABLE_JPEG@)
+if(NANA_ENABLE_JPEG)
   target_link_libraries(unofficial::nana::nana INTERFACE ${JPEG_LIBRARIES})
 endif()


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #
Build in Windows 10.

- Which triplets are supported/not supported? Have you updated the CI baseline?
Supported x64-windows, in x64-linux I don't know how to fix issue with fontconfig yet.
vcpkg/installed/x64-linux/lib/libfontconfig.a(fcfreetype.c.o): undefined reference to symbol 'FT_Get_Postscript_Name'

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
